### PR TITLE
use rank to match logic exhibited by bot

### DIFF
--- a/src/data/Queries.ts
+++ b/src/data/Queries.ts
@@ -388,7 +388,7 @@ WITH aggregated AS (
     [public.users].earned_points
 )
 SELECT
-  ROW_NUMBER() OVER (ORDER BY earned_points DESC) as rank,
+  RANK() OVER (ORDER BY earned_points DESC) as rank,
   *
 FROM aggregated
 ORDER BY earned_points DESC;


### PR DESCRIPTION
Changes method used in query to match ranking logic currently exhibited by the gotx completion bot. Bot assigns highest rank per tied score, currently the site uses row number instead of rank and thus doesn't create ties.

Before:
<img width="585" height="157" alt="image" src="https://github.com/user-attachments/assets/cd754eb3-27aa-4a8f-9800-fa4bf8c65b33" />


After: 
<img width="566" height="179" alt="image" src="https://github.com/user-attachments/assets/147cdae9-88c1-4484-b504-4143e7500b06" />
